### PR TITLE
Improve testing, add a new test, fix some things

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,21 +1,25 @@
 name = "BridgeSDEInference"
 uuid = "46d747a0-b9e1-11e9-14b5-615c73e45078"
 authors = ["Marcin Mider <marcin.mider@gmail.com>", "mschauer <moritzschauer@web.de>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Bridge = "2d3116d5-4b8f-5680-861c-71f149790274"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GaussianDistributions = "43dcc890-d446-5863-8d1a-14597580bb8d"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Statistics", "Random", "LinearAlgebra"]
 
 [compat]
 julia = "1"

--- a/src/guid_prop_bridge.jl
+++ b/src/guid_prop_bridge.jl
@@ -485,11 +485,11 @@ function llikelihood(::LeftRule, X::SamplePath, P::GuidPropBridge; skip = 0)
                  * (tt[i+1]-tt[i]) )
 
         if !constdiff(P)
-            H = H((i,s), x, P)
+            Hi = H((i,s), x, P)
             som -= ( 0.5*tr( (a((i,s), x, target(P))
-                             - aitilde((i,s), x, P))*H ) * (tt[i+1]-tt[i]) )
+                             - a((i,s), x, auxiliary(P)))*Hi ) * (tt[i+1]-tt[i]) )
             som += ( 0.5*( r'*(a((i,s), x, target(P))
-                           - aitilde((i,s), x, P))*r ) * (tt[i+1]-tt[i]) )
+                           - a((i,s), x, auxiliary(P)))*r ) * (tt[i+1]-tt[i]) )
         end
     end
     som

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using Test
 
-using Bridge, StaticArrays, Distributions
+using Bridge, BridgeSDEInference, StaticArrays, Distributions
 using Statistics, Random, LinearAlgebra
-POSSIBLE_PARAMS = [:regular, :simpleAlter, :complexAlter, :simpleConjug,
-                   :complexConjug]
-SRC_DIR = joinpath(Base.source_dir(), "..", "src")
 
+const BSI = BridgeSDEInference
+using BridgeSDEInference: ℝ
 
 include("test_ODE_solver_change_pt.jl")
 include("test_blocking.jl")
+include("test_measchange.jl")

--- a/test/test_blocking.jl
+++ b/test/test_blocking.jl
@@ -1,19 +1,16 @@
+POSSIBLE_PARAMS = [:regular, :simpleAlter, :complexAlter, :simpleConjug,
+                   :complexConjug]
+SRC_DIR = joinpath(Base.source_dir(), "..", "src")
+
 parametrisation = POSSIBLE_PARAMS[5]
-include(joinpath(SRC_DIR, "types.jl"))
-include(joinpath(SRC_DIR, "fitzHughNagumo.jl"))
-include(joinpath(SRC_DIR, "guid_prop_bridge.jl"))
-include(joinpath(SRC_DIR, "blocking_schedule.jl"))
-include(joinpath(SRC_DIR, "vern7.jl"))
-
-
 
 function blocking_test_prep(obs=ℝ.([1.0, 1.2, 0.8, 1.3, 2.0]),
                             tt=[0.0, 1.0, 1.5, 2.3, 4.0],
                             knots=collect(1:length(obs)-2)[1:1:end],
                             changePtBuffer=100)
     θ₀ = [10.0, -8.0, 25.0, 0.0, 3.0]
-    P˟ = FitzhughDiffusion(θ₀...)
-    P̃ = [FitzhughDiffusionAux(θ₀..., t₀, u[1], T, v[1]) for (t₀,T,u,v)
+    P˟ = BSI.FitzhughDiffusion(θ₀...)
+    P̃ = [BSI.FitzhughDiffusionAux(θ₀..., t₀, u[1], T, v[1]) for (t₀,T,u,v)
          in zip(tt[1:end-1], tt[2:end], obs[1:end-1], obs[2:end])]
     L = @SMatrix [1. 0.]
     Σdiagel = 10^(-10)
@@ -23,32 +20,32 @@ function blocking_test_prep(obs=ℝ.([1.0, 1.2, 0.8, 1.3, 2.0]),
     Σs = [Σ for _ in P̃]
     τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
     m = length(obs) - 1
-    P = Array{ContinuousTimeProcess,1}(undef,m)
+    P = Array{BSI.ContinuousTimeProcess,1}(undef,m)
     dt = 1/50
     for i in m:-1:1
         numPts = Int64(ceil((tt[i+1]-tt[i])/dt))+1
         t = τ(tt[i], tt[i+1]).( range(tt[i], stop=tt[i+1], length=numPts) )
-        P[i] = ( (i==m) ? GuidPropBridge(Float64, t, P˟, P̃[i], Ls[i], obs[i+1], Σs[i];
-                                         changePt=NoChangePt(changePtBuffer),
-                                         solver=Vern7()) :
-                          GuidPropBridge(Float64, t, P˟, P̃[i], Ls[i], obs[i+1], Σs[i],
+        P[i] = ( (i==m) ? BSI.GuidPropBridge(Float64, t, P˟, P̃[i], Ls[i], obs[i+1], Σs[i];
+                                         changePt=BSI.NoChangePt(changePtBuffer),
+                                         solver=BSI.Vern7()) :
+                          BSI.GuidPropBridge(Float64, t, P˟, P̃[i], Ls[i], obs[i+1], Σs[i],
                                          P[i+1].H[1], P[i+1].Hν[1], P[i+1].c[1];
-                                         changePt=NoChangePt(changePtBuffer),
-                                         solver=Vern7()) )
+                                         changePt=BSI.NoChangePt(changePtBuffer),
+                                         solver=BSI.Vern7()) )
     end
 
     T = SArray{Tuple{2},Float64,1,2}
-    TW = typeof(sample([0], Wiener{Float64}()))
-    TX = typeof(SamplePath([], zeros(T, 0)))
+    TW = typeof(sample([0], BSI.Wiener{Float64}()))
+    TX = typeof(BSI.SamplePath([], zeros(T, 0)))
     XX = Vector{TX}(undef,m)
     WW = Vector{TW}(undef,m)
     for i in 1:m
-        XX[i] = SamplePath(P[i].tt, zeros(T, length(P[i].tt)))
+        XX[i] = BSI.SamplePath(P[i].tt, zeros(T, length(P[i].tt)))
         XX[i].yy .= [T(obs[i+1][1], i) for _ in 1:length(XX[i].yy)]
     end
 
-    blockingParams = (knots, 10^(-7), SimpleChangePt(changePtBuffer))
-    𝔅 = ChequeredBlocking(blockingParams..., P, WW, XX)
+    blockingParams = (knots, 10^(-7), BSI.SimpleChangePt(changePtBuffer))
+    𝔅 = BSI.ChequeredBlocking(blockingParams..., P, WW, XX)
     for i in 1:m
         𝔅.XXᵒ[i].yy .= [T(obs[i+1][1], 10+i) for _ in 1:length(XX[i].yy)]
     end
@@ -70,8 +67,8 @@ end
         @test 𝔅.knots[2] == [2]
         @test 𝔅.blocks[1] == [[1], [2, 3], [4]]
         @test 𝔅.blocks[2] == [[1, 2], [3, 4]]
-        @test 𝔅.changePts[1] == [SimpleChangePt(100), NoChangePt(100), SimpleChangePt(100), NoChangePt(100)]
-        @test 𝔅.changePts[2] == [NoChangePt(100), SimpleChangePt(100), NoChangePt(100), NoChangePt(100)]
+        @test 𝔅.changePts[1] == [BSI.SimpleChangePt(100), BSI.NoChangePt(100), BSI.SimpleChangePt(100), BSI.NoChangePt(100)]
+        @test 𝔅.changePts[2] == [BSI.NoChangePt(100), BSI.SimpleChangePt(100), BSI.NoChangePt(100), BSI.NoChangePt(100)]
         @test 𝔅.vs == obs[2:end]
         @test 𝔅.Ls[1] == [I, L, I, L]
         @test 𝔅.Ls[2] == [L, I, L, L]
@@ -80,18 +77,18 @@ end
     end
 
     θ = [10.0, -8.0, 15.0, 0.0, 3.0]
-    𝔅 = next(𝔅, 𝔅.XX, θ)
+    𝔅 = BSI.next(𝔅, 𝔅.XX, θ)
 
     @testset "validity of blocking state after calling next" begin
         @test 𝔅.idx == 2
         @testset "checking if θ has been propagated everywhere" for i in 1:length(tt)-1
-            @test params(𝔅.P[i].Target) == θ
-            @test params(𝔅.P[i].Pt) == θ
+            @test BSI.params(𝔅.P[i].Target) == θ
+            @test BSI.params(𝔅.P[i].Pt) == θ
         end
         @test [𝔅.P[i].Σ for i in 1:length(tt)-1 ] == 𝔅.Σs[2] == [Σ, I*ϵ, Σ, Σ]
         @test [𝔅.P[i].L for i in 1:length(tt)-1 ] == 𝔅.Ls[2] == [L, I, L, L]
         @test [𝔅.P[i].v for i in 1:length(tt)-1 ] == [obs[2], 𝔅.XX[2].yy[end], obs[4], obs[5]]
-        @test [𝔅.P[i].changePt for i in 1:length(tt)-1 ] == 𝔅.changePts[2] == [NoChangePt(100), SimpleChangePt(100), NoChangePt(100), NoChangePt(100)]
+        @test [𝔅.P[i].changePt for i in 1:length(tt)-1 ] == 𝔅.changePts[2] == [BSI.NoChangePt(100), BSI.SimpleChangePt(100), BSI.NoChangePt(100), BSI.NoChangePt(100)]
     end
 
     θᵒ = [1.0, -7.0, 10.0, 2.0, 1.0]
@@ -110,17 +107,17 @@ end
         end
     end
 
-    𝔅 = next(𝔅, 𝔅.XX, θᵒ)
+    𝔅 = BSI.next(𝔅, 𝔅.XX, θᵒ)
 
     @testset "validity of blocking state after second call to next" begin
         @test 𝔅.idx == 1
         @testset "checking if θᵒ has been propagated everywhere" for i in 1:length(tt)-1
-            @test params(𝔅.P[i].Target) == θᵒ
-            @test params(𝔅.P[i].Pt) == θᵒ
+            @test BSI.params(𝔅.P[i].Target) == θᵒ
+            @test BSI.params(𝔅.P[i].Pt) == θᵒ
         end
         @test [𝔅.P[i].Σ for i in 1:length(tt)-1 ] == 𝔅.Σs[1] == [I*ϵ, Σ, I*ϵ, Σ]
         @test [𝔅.P[i].L for i in 1:length(tt)-1 ] == 𝔅.Ls[1] == [I, L, I, L]
         @test [𝔅.P[i].v for i in 1:length(tt)-1 ] == [𝔅.XX[1].yy[end], obs[3], 𝔅.XX[3].yy[end], obs[5]]
-        @test [𝔅.P[i].changePt for i in 1:length(tt)-1 ] == 𝔅.changePts[1] == [SimpleChangePt(100), NoChangePt(100), SimpleChangePt(100), NoChangePt(100)]
+        @test [𝔅.P[i].changePt for i in 1:length(tt)-1 ] == 𝔅.changePts[1] == [BSI.SimpleChangePt(100), BSI.NoChangePt(100), BSI.SimpleChangePt(100), BSI.NoChangePt(100)]
     end
 end

--- a/test/test_measchange.jl
+++ b/test/test_measchange.jl
@@ -54,7 +54,6 @@ function test_measchange()
     solve!(Euler(), X, x0, W, P)
     @test v1 ≈ X.yy[end]
 
-    Pᵒ = BridgeSDEInference.GuidPropBridge(eltype(x0), t, P, P̃, L, v, Σ)
 
 
     K = 50

--- a/test/test_measchange.jl
+++ b/test/test_measchange.jl
@@ -35,7 +35,6 @@ function test_measchange()
     P = TargetSDE()
     v = 𝕏(pi/2)
 
-    P̃ = LinearSDE(Bridge.σ(T, v, P))
     x0 = 𝕏(-pi/2)
 
     t = 0:0.01*f*fextra:T

--- a/test/test_measchange.jl
+++ b/test/test_measchange.jl
@@ -50,7 +50,11 @@ function test_measchange()
 
     sample!(W, Wnr)
     X = solve(Euler(), x0, W, P)
+    v1 = X.yy[end]
+    X.yy[end] = zero(v1)
     solve!(Euler(), X, x0, W, P)
+    @test v1 ≈ X.yy[end]
+
     Pᵒ = BridgeSDEInference.GuidPropBridge(eltype(x0), t, P, P̃, L, v, Σ)
 
 

--- a/test/test_measchange.jl
+++ b/test/test_measchange.jl
@@ -1,0 +1,113 @@
+# Test that the transition density
+# in a non-linear, non-homogenous, non-constant diffusivity model
+# estimated by forward simulation
+# agrees with the density obtained from the linearisation
+# reweighted with importance weights using guided proposals.
+const 𝕏 = SVector{1}
+using GaussianDistributions
+
+struct TargetSDE <: Bridge.ContinuousTimeProcess{Float64}
+end
+struct LinearSDE{T}  <: Bridge.ContinuousTimeProcess{Float64}
+    σ::T
+end
+Bridge.b(s, x, P::TargetSDE) = -0.1x + .5sin(x[1]) + 0.5sin(s/4)
+Bridge.b(s, x, P::LinearSDE) = Bridge.B(s, P)*x + Bridge.β(s, P)
+Bridge.B(s, P::LinearSDE) = SMatrix{1}(-0.1)
+Bridge.β(s, P::LinearSDE) = 𝕏(0.5sin(s/4))
+
+Bridge.σ(s, x, P::TargetSDE) = SMatrix{1}(2.0 + 0.5cos(x[1]))
+Bridge.σ(s, x, P::LinearSDE) = P.σ
+Bridge.σ(s, P::LinearSDE) = P.σ
+Bridge.a(s, P::LinearSDE) = P.σ^2
+
+Bridge.constdiff(::TargetSDE) = false
+Bridge.constdiff(::LinearSDE) = true
+
+binind(r, x) = searchsortedfirst(r, x) - 1
+
+
+function test_measchange()
+    Random.seed!(1)
+    fextra = 1.
+    f = 1.0
+    T = round(f*4*pi, digits=2)
+    P = TargetSDE()
+    v = 𝕏(pi/2)
+
+    P̃ = LinearSDE(Bridge.σ(T, v, P))
+    x0 = 𝕏(-pi/2)
+
+    t = 0:0.01*f*fextra:T
+    t = Bridge.tofs.(t, 0, T)
+    W = Bridge.samplepath(t, 𝕏(0.0))
+
+    Wnr =  Wiener{𝕏{Float64}}()
+
+    Σ = SMatrix{1}(0.1)
+    L = SMatrix{1}(1.0)
+    Noise = Gaussian(𝕏(0.0), Σ)
+
+    sample!(W, Wnr)
+    X = solve(Euler(), x0, W, P)
+    solve!(Euler(), X, x0, W, P)
+    Pᵒ = BridgeSDEInference.GuidPropBridge(eltype(x0), t, P, P̃, L, v, Σ)
+
+
+    K = 50
+    vrange = range(-10,10, length=K+1)
+    vints = [(vrange[i], vrange[i+1]) for i in 1:K]
+
+    k = 1
+    N = 50000
+
+    # Forward simulation
+
+    vs = Float64[]
+    for i in 1:N
+        sample!(W, Wnr)
+        solve!(Euler(), X, x0, W, P)
+        v = L*X.yy[end] + rand(Noise)
+        push!(vs, v[1])
+    end
+
+    counts = zeros(K+2)
+    [counts[binind(vrange, v)+1] += 1 for v in vs]
+    counts /= length(vs)
+
+    wcounts = zeros(K)
+
+
+    VProp = Uniform(-10,10)
+
+    fpt = fill(NaN, 1)
+    v = 𝕏(0.0)
+    P̃ = LinearSDE(Bridge.σ(T, v, P)) # use a law with large variance
+    Pᵒ = BridgeSDEInference.GuidPropBridge(eltype(x0), t, P, P̃, L, v, Σ)
+
+    # Guided proposals
+
+    for i in 1:N
+        v = 𝕏(5*rand(VProp))
+        while !((binind(vrange, v[1]) in 1:K))
+            v = 𝕏(5*rand(VProp))
+        end
+        # other possibility: change proposal each step
+    #    P̃ = LinearSDE(Bridge.σ(T, v, P))
+        Pᵒ = BridgeSDEInference.GuidPropBridge(eltype(x0), t, P, P̃, L, v, Σ)
+
+        sample!(W, Wnr)
+        solve!(Euler(), X, x0, W, Pᵒ)
+        ll = BSI.pathLogLikhd(BridgeSDEInference.PartObs(), [X], [Pᵒ], 1:1, fpt, skipFPT=true)
+        ll += BSI.lobslikelihood(Pᵒ, x0)
+        ll -= logpdf(VProp, v[1])
+        wcounts[binind(vrange, v[1])] += exp(ll)/N
+    end
+    bias = wcounts - counts[2:end-1]
+
+    @testset "Stastical correctness guided proposals" begin
+        @test norm(bias) < 0.05
+    end
+end
+
+test_measchange()


### PR DESCRIPTION
This really nice! 

I test that the (bimodal!) transition density
in a non-linear, non-homogenous, non-constant diffusivity model,
estimated by forward simulation
agrees with the density obtained from the linearisation
reweighted with importance weights using guided proposals. Clearly, not even wrong by a factor:

<img width="823" alt="Screenshot 2019-09-14 at 19 07 29" src="https://user-images.githubusercontent.com/1923437/64911515-f1f90700-d722-11e9-9980-055b0ffa8ff6.png">

Here some bridges from the forward simulation (color doesn't have a meaning):

<img width="752" alt="Screenshot 2019-09-14 at 19 06 58" src="https://user-images.githubusercontent.com/1923437/64911516-f4f3f780-d722-11e9-8e49-9fa13d0b3f17.png">